### PR TITLE
fix auto-updater to work across URL changes

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,4 +1,4 @@
-@ant-name@=AutoReviewComments for Stack Exchange sites
+@ant-name@=AutoReviewComments
 @ant-description@=No more re-typing the same comments over and over!
 @ant-version@=1.3.2.1
 @ant-homepage@=https://github.com/Benjol/SE-AutoReviewComments

--- a/src/.modules/autoupdater.js
+++ b/src/.modules/autoupdater.js
@@ -1,39 +1,60 @@
-//**selfupdatingscript starts here (see https://gist.github.com/raw/874058/selfupdatingscript.user.js)
+// Self Updating Userscript, see https://gist.github.com/Benjol/874058
+// (the first line of this template _must_ be a comment!)
 var VERSION = '@ant-version@';
-var URL = "https://github.com/Benjol/SE-AutoReviewComments/raw/master/dist/autoreviewcomments.min.user.js";
+var URL = "https://raw.github.com/Benjol/SE-AutoReviewComments/master/dist/autoreviewcomments.user.js";
 
-if(window["selfUpdaterCallback:" + URL]) {
-  window["selfUpdaterCallback:" + URL](VERSION);
+// This hack is necessary to bring people up from the last working auto-uptate gist
+// release if they manually installed the latest version. (can be removed after some
+// time has passed and last released version is at least 1.3.4)
+for (var key in window) {
+  if (key.indexOf('selfUpdaterCallback') != -1) {
+    window[key](VERSION);
+    return;
+  }
+}
+// End hack
+
+if(window["AutoReviewComments_AutoUpdateCallback"]) {
+  window["AutoReviewComments_AutoUpdateCallback"](VERSION);
   return;
 }
 
 function updateCheck(notifier) {
-  window["selfUpdaterCallback:" + URL] = function (newver) {
-    if(newver > VERSION) notifier(newver, VERSION, URL);
-  }
+  window["AutoReviewComments_AutoUpdateCallback"] = function (newver) {
+      if(newver > VERSION) notifier(newver, VERSION, URL);
+    }
   $("<script />").attr("src", URL).appendTo("head");
 }
-//**selfupdatingscript ends here (except for call to updateCheck further down in code)
 
-//Check to see if a new version has become available since last check
-// only checks once a day
+// Check to see if a new version has become available since last check
+// - only checks once a day
+// - does not check for first time visitors, shows them a welcome message instead
+// - called at the end of the main script if function exists
 function CheckForNewVersion(popup) {
   var today = (new Date().setHours(0, 0, 0, 0));
-  var lastCheck = GetStorage("LastUpdateCheckDay");
-  if(lastCheck == null) { //first time visitor
+  var LastUpdateCheckDay = GetStorage("LastUpdateCheckDay");
+  if(LastUpdateCheckDay == null) { //first time visitor
     ShowMessage(popup, "Please read this!", 'Thanks for installing this script. \
                             Please note that you can EDIT the texts inline by double-clicking them. \
                             For other options, please see the README at <a href="https://github.com/Benjol/SE-AutoReviewComments" target="_blank">here</a>.',
                 function () { });
-  }
-  if(lastCheck != null && lastCheck != today) {
-    var lastVersion = GetStorage("LastVersionAcknowledged");
-    updateCheck(function (newver, oldver, url) {
-      if(newver != lastVersion) {
-        ShowMessage(popup, "New Version!", 'A new version (' + newver + ') of the <a href="http://stackapps.com/q/2116">AutoReviewComments</a> userscript is now available, see the <a href="https://github.com/Benjol/SE-AutoReviewComments/releases">release notes</a> for details. (this notification will only appear once per new version, and per site)',
+  } else if ( LastUpdateCheckDay != today) {
+    updateCheck(function (newver, oldver, install_url) {
+      if(newver != GetStorage("LastVersionAcknowledged")) {
+        ShowMessage(popup, "New Version!", 'A new version (' + newver + ') of the <a href="http://stackapps.com/q/2116">AutoReviewComments</a> userscript is now available, see the <a href="https://github.com/Benjol/SE-AutoReviewComments/releases">release notes</a> for details or <a href="' + install_url + '">click here</a> to install now.',
                     function () { SetStorage("LastVersionAcknowledged", newver); });
       }
     });
   }
   SetStorage("LastUpdateCheckDay", today);
 }
+
+/* How does this work?
+   1. The installed script loads first, and sets the local VERSION variable with the currently installed version number
+   2. window["AutoReviewComments_AutoUpdateCallback"] is not defined, so this is skipped
+   3. When updateCheck() is called, it defines window["AutoReviewComments_AutoUpdateCallback"], which retains the installed version number in VERSION (closure)
+   4. updateCheck() then loads the external version of the script into the page header
+   5. when the external version of the script loads, it defines its own local VERSION with the external (potentially new) version number
+   6. window["AutoReviewComments_AutoUpdateCallback"] is now defined, so it is invoked, and the external version number is passed in
+   7. if the external version number (ver) is greater than the installed version (VERSION), the notification is invoked
+ */

--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -21,7 +21,6 @@ with_jquery(function ($) {
   StackExchange.ready(function () {
     //@ant-modules-autoupdater@
 
-    //autoreviewcomments script starts here
     var siteurl = window.location.hostname;
     var arr = document.title.split(' - ');
     var sitename = arr[arr.length - 1];


### PR DESCRIPTION
This fixes the namespace issue that was causing the auto-updater to fail
any time the next available version has a different auto-update URL. It
also includes a hack to be able to update any previous versions that may
have gotten installed manually that have correct links but broken code.
