### PR TITLE
Don't attempt to build CRX on MacOS

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -261,7 +261,7 @@
     <if>
       <os family="mac"/>
       <then>
-        <echo message="Building the Chrome CRX archive is currently not supported on the MacOS operating system family!" if="isMac"/>
+        <echo message="Building the Chrome CRX archive is currently not supported on the MacOS operating system family!"/>
       </then>
       <else>
         <exec executable="${sdk.buildcrx}" failonerror="true">


### PR DESCRIPTION
For now, I figured this would be a good solution. This recognizes the problematic condition, fails gracefully and doesn't attempt to run a binary it can't execute on the OS anyway.

I was unable to test this though.
