### PR TITLE
Fixed chrome site list not being properly generated.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -144,8 +144,8 @@
   <target name="sites-userscript">
     <loadfile property="sites-userscript" srcFile="${build.sites}">
       <filterchain>
-	<replacestring from="\." to="."/>
-	<replacestring from="https?" to="http*"/>
+        <replacestring from="\." to="."/>
+        <replacestring from="https?" to="http*"/>
         <prefixlines prefix="// @include "/>
       </filterchain>
     </loadfile>
@@ -153,12 +153,13 @@
   <target name="sites-chrome">
     <loadfile property="sites-chrome-list-in" srcFile="${build.sites}">
       <filterchain>
-	<replacestring from="https?" to="*"/>
-	<replacestring from="\." to="."/>
+        <replacestring from="https?" to="*"/>
+        <replacestring from="\." to="."/>
         <prefixlines prefix="&quot;"/>
         <suffixlines suffix="&quot;,"/>
       </filterchain>
     </loadfile>
+    <!-- Remove last trailing comma from property. -->
     <propertyregex property="sites-chrome-list" input="${sites-chrome-list-in}" regexp=",$" replace=""/>
   </target>
   <target name="sites-string-list">
@@ -168,6 +169,7 @@
         <suffixlines suffix="&quot;,"/>
       </filterchain>
     </loadfile>
+    <!-- Remove last trailing comma from property. -->
     <propertyregex property="sites-string-list" input="${sites-string-list-in}" regexp=",$" replace=""/>
   </target>
 


### PR DESCRIPTION
The issue was caused by reading the sites list into the wrong property. The regular expression used to filter it was performed on a non-existing property.
