### PR TITLE
Fixed Insert-Now-Arrow for Chrome/Windows

### DIFF
--- a/src/.templates/css.html
+++ b/src/.templates/css.html
@@ -111,7 +111,7 @@
     right: 0;
     height: 100%;
     margin: 0;
-    font-size: 20px;
+    font-size: 300%;
     color: transparent;
     background-color: transparent;
     border: none;

--- a/src/.templates/option.html
+++ b/src/.templates/option.html
@@ -3,6 +3,6 @@
   <label for="comment-$ID$">
     <span id="name-$ID$" class="action-name">$NAME$</span>
     <span id="desc-$ID$" class="action-desc">$DESCRIPTION$</span>
-    <button class="quick-insert" title="Insert now">⬇</button>
+    <button class="quick-insert" title="Insert now">↓</button>
   </label>
 </li>


### PR DESCRIPTION
Now using a larger version of the thin arrow.
![](http://i.imgur.com/9PAHtm2.png)

It's not the greatest solution, but it's okay. I would prefer to include an icon font like FontAwesome, but that feel like overkill.
