### PR TITLE
Fixed double-auto link

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -551,7 +551,7 @@ with_jquery(function ($) {
         _internalInjector( triggerElement );
       } );
     }
-    attachAutoLinkInjector( ".comments-link", findCommentElements, injectAutoLink, autoLinkAction );
+    attachAutoLinkInjector( ".js-add-link", findCommentElements, injectAutoLink, autoLinkAction );
     attachAutoLinkInjector( ".edit-post", findEditSummaryElements, injectAutoLinkEdit, autoLinkAction );
     attachAutoLinkInjector( ".close-question-link", findClosureElements, injectAutoLinkClosure, autoLinkAction );
 


### PR DESCRIPTION
The "show X more comments" link also has the "comments-link" class, resulting in multiple "auto" links being created when it is clicked.
