### PR TITLE
Make Ajax use the same protocol as the main URL (so it works with https)

### DIFF
--- a/autoreviewcomments.user.js
+++ b/autoreviewcomments.user.js
@@ -247,7 +247,7 @@ function CheckForNewVersion(popup) {
       }
       $.ajax({
         type: "GET",
-        url: 'http://api.stackexchange.com/2.2/users/' + userid + '?site=' + siteurl + '&jsonp=?',
+        url: '//api.stackexchange.com/2.2/users/' + userid + '?site=' + siteurl + '&jsonp=?',
         dataType: "jsonp",
         timeout: 2000,
         success: function (data) {


### PR DESCRIPTION
When using SE with the UserScript in Firefox via HTTPS, the Ajax subrequest for user details (e.g. to check if it's a new user) failed as "loading of mixed content" gets blocked. This commit fixes this by having Ajax inherit the protocol used for the main page instead of explicitly specifying `http:` (`//` instead of `http://`).