### PR TITLE
fix for #87: getUserId fails with FF36 due to broken reference

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -700,7 +700,7 @@ with_jquery(function ($) {
       StackExchange.helpers.bindMovablePopups();
 
       //Get user info and inject
-      var userid = getUserId($(this));
+      var userid = getUserId(targetObject);
       getUserInfo(userid, popup);
       OP = getOP();
 


### PR DESCRIPTION
Might need another check by someone else (maybe with a different browser, or at least different Firefox version) – but looks like I've nailed it now. `targetObject` is the textarea passed to the wrapping function, so it should definiely match.