### PR TITLE
Improved LAF of quick-insert button

### DIFF
--- a/src/.templates/css.html
+++ b/src/.templates/css.html
@@ -106,6 +106,9 @@
   }
 
   .auto-review-comments.popup .main .action-list li label .quick-insert {
+    /* Hide the whole button by default. We'll show it when the li is hovered */
+    display: none;
+
     position: absolute;
     top: 0;
     right: 0;
@@ -119,12 +122,16 @@
     cursor: pointer;
 
     /* Override default button styles */
-    background-color: transparent;
-    background: none;
+    background-color: rgba(0,0,0,0.1);
+    background: rgba(0,0,0,0.1);
 
     box-shadow: none;
     -moz-box-shadow: none;
     -webkit-box-shadow: none;
+  }
+
+  .auto-review-comments.popup .main .action-list li:hover label .quick-insert {
+    display: block;
   }
 
   .auto-review-comments.popup .main .action-list li label .quick-insert:hover {


### PR DESCRIPTION
Slight improvement over the previous change. Makes the quick-insert button only visible when the comment is hovered over, but also gives it a stronger background.