### PR TITLE
Fix breakage with new Stack Overflow top-bar

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -135,13 +135,8 @@ with_jquery(function ($) {
     }
 
     // Get the Id of the logged-in user
-    function getLoggedInUserId() {
-      var profileMeElement = document.getElementsByClassName('profile-me');
-      if ( profileMeElement.length && profileMeElement[0].href.match(/\/users\/(\d+)\/.*/i) ) {
-        return RegExp.$1;
-      } else {
-        return '';
-      }
+    function getLoggedInUserId() { 
+      return StackExchange.options && StackExchange.options.user ? StackExchange.options.user.userId : ''; 
     }
 
     //Get userId for post


### PR DESCRIPTION
New top bar on Stack Overflow (http://stackoverflow.blog/2017/02/Why-Stack-Overflow-Redesigned-the-Top-Navigation/) changes the markup for the user link; this breaks the script's attempt to retrieve the user ID. 

![Uncaught TypeError: Cannot read property 'href' of undefined](https://cloud.githubusercontent.com/assets/4950451/22935683/85c5dae6-f290-11e6-993b-aa334fd8aa5a.png)


Simplest fix for this is to just pull the ID from the user options object, which should be considerably more resilient to such changes. 