### PR TITLE
Exclude SE Chat

### DIFF
--- a/dist/autoreviewcomments.user.js
+++ b/dist/autoreviewcomments.user.js
@@ -14,6 +14,9 @@
 // @include /^https?:\/\/(.*\.)?mathoverflow\.com/.*$/
 // @include /^https?:\/\/discuss\.area51\.stackexchange\.com/.*$/
 // @include /^https?:\/\/stackapps\.com/.*$/
+// @exclude *://chat.stackexchange.com/*
+// @exclude *://chat.stackoverflow.com/*
+// @exclude *://chat.meta.stackexchange.com/*
 // ==/UserScript==
 */
 


### PR DESCRIPTION
UserScript currently tries to run on the SE Chat, and while all this doesn't do any damage, it leaves a big error in the console which annoys me

Only change is the addition of these three lines:
```
// @exclude *://chat.stackexchange.com/*
// @exclude *://chat.stackoverflow.com/*
// @exclude *://chat.meta.stackexchange.com/*
```
Currently got 1.4.3 running with those added lines, so can confirm it works with no problems