### PR TITLE
Build userscript site excludes

### DIFF
--- a/build.excludes
+++ b/build.excludes
@@ -1,0 +1,3 @@
+*://chat.stackexchange.com/*
+*://chat.stackoverflow.com/*
+*://chat.meta.stackexchange.com/*

--- a/build.xml
+++ b/build.xml
@@ -9,6 +9,7 @@
   <property name="build.prop" value="${basedir}/build.properties"/>
   <!-- The sites our script should run on are defined in this file -->
   <property name="build.sites" value="${basedir}/build.sites"/>
+  <property name="build.excludes" value="${basedir}/build.excludes"/>
   <property name="encoding" value="UTF-8"/>
 
   <property name="name" value="autoreviewcomments"/>
@@ -117,7 +118,7 @@
     </apply>
   </target>
 
-  <target name="tokenreplace" depends="sites, sites-userscript, sites-chrome, sites-firefox, compress-templates">
+  <target name="tokenreplace" depends="sites, sites-userscript, excludes-userscript, sites-chrome, sites-firefox, compress-templates">
     <!-- Replace templates. -->
     <loadfile srcfile="${buildDir}/.templates/css.html" property="ant-templates-css"/>
     <replace dir="${buildDir}" token="@ant-templates-css@" value="${ant-templates-css}"/>
@@ -137,6 +138,7 @@
 
     <replace dir="${buildDir}" token="@ant-sites@" value="${sites}" encoding="${encoding}"/>
     <replace dir="${buildDir}" token="// @ant-sites-userscript@" value="${sites-userscript}" encoding="${encoding}"/>
+    <replace dir="${buildDir}" token="// @ant-excludes-userscript@" value="${excludes-userscript}" encoding="${encoding}"/>
     <replace dir="${buildDir}" token="&quot;@ant-sites-chrome-list@&quot;" value="${sites-chrome-list}"
              encoding="${encoding}"/>
     <replace dir="${buildDir}" token="&quot;@ant-sites-firefox-list@&quot;" value="${sites-firefox-list}"
@@ -208,6 +210,17 @@
     </loadfile>
     <!-- Remove last trailing comma from property. -->
     <propertyregex property="sites-firefox-list" input="${sites-firefox-list-in}" regexp=",[\r\n]*$" replace=""/>
+  </target>
+
+  <!-- Construct the list of exclude sites as required by the userscript.
+       For reference see: http://wiki.greasespot.net/Include_and_exclude_rules -->
+  <target name="excludes-userscript">
+    <loadfile property="excludes-userscript" srcFile="${build.excludes}">
+      <filterchain>
+        <!-- Prefix all lines with the mandatory @exclude comment. -->
+        <prefixlines prefix="// @exclude "/>
+      </filterchain>
+    </loadfile>
   </target>
 
   <!-- Build the userscript. -->

--- a/dist/autoreviewcomments.min.user.js
+++ b/dist/autoreviewcomments.min.user.js
@@ -15,6 +15,10 @@
 // @include /^https?:\/\/(.*\.)?mathoverflow\.com/.*$/
 // @include /^https?:\/\/discuss\.area51\.stackexchange\.com/.*$/
 // @include /^https?:\/\/stackapps\.com/.*$/
+// @exclude *://chat.stackexchange.com/*
+// @exclude *://chat.stackoverflow.com/*
+// @exclude *://chat.meta.stackexchange.com/*
+
 // ==/UserScript==
 */
 function with_jquery(d){var u=document.createElement("script");u.type="text/javascript";u.textContent="("+d.toString()+")(jQuery)";document.body.appendChild(u)}

--- a/dist/autoreviewcomments.user.js
+++ b/dist/autoreviewcomments.user.js
@@ -17,6 +17,7 @@
 // @exclude *://chat.stackexchange.com/*
 // @exclude *://chat.stackoverflow.com/*
 // @exclude *://chat.meta.stackexchange.com/*
+
 // ==/UserScript==
 */
 
@@ -226,8 +227,8 @@ function CheckForNewVersion(popup) {
     }
 
     // Get the Id of the logged-in user
-    function getLoggedInUserId() { 
-      return StackExchange.options && StackExchange.options.user ? StackExchange.options.user.userId : ''; 
+    function getLoggedInUserId() {
+      return StackExchange.options && StackExchange.options.user ? StackExchange.options.user.userId : '';
     }
 
     //Get userId for post
@@ -749,7 +750,7 @@ function CheckForNewVersion(popup) {
       if( existingAutoLinks && existingAutoLinks.length ) {
         return;
       }
-      
+
       var _autoLinkAction = function(){
         what( placeCommentIn, Target.Closure );
       };

--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -7,6 +7,7 @@
 // @homepage       @ant-homepage@
 // @grant          none
 // @ant-sites-userscript@
+// @ant-excludes-userscript@
 // ==/UserScript==
 */
 
@@ -135,8 +136,8 @@ with_jquery(function ($) {
     }
 
     // Get the Id of the logged-in user
-    function getLoggedInUserId() { 
-      return StackExchange.options && StackExchange.options.user ? StackExchange.options.user.userId : ''; 
+    function getLoggedInUserId() {
+      return StackExchange.options && StackExchange.options.user ? StackExchange.options.user.userId : '';
     }
 
     //Get userId for post
@@ -658,7 +659,7 @@ with_jquery(function ($) {
       if( existingAutoLinks && existingAutoLinks.length ) {
         return;
       }
-      
+
       var _autoLinkAction = function(){
         what( placeCommentIn, Target.Closure );
       };


### PR DESCRIPTION
Using a build.excludes file (like build.sites), to avoid them getting
lost when the dist userscript is rebuilt from src.