### PR TITLE
Add styling

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -805,7 +805,7 @@ with_jquery(function($) {
       var _autoLinkAction = function() {
         what(placeCommentIn, posttype);
       };
-      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\">auto</a>").click(_autoLinkAction));
+      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\" style=\"margin-left: 1em;\">auto</a>").click(_autoLinkAction));
       autoLink.insertAfter(where);
     }
     /**
@@ -834,7 +834,7 @@ with_jquery(function($) {
       var _autoLinkAction = function() {
         what(placeCommentIn, posttype);
       };
-      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\">auto</a>").click(_autoLinkAction));
+      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\" style=\"margin-left: 1em;\">auto</a>").click(_autoLinkAction));
       autoLink.insertAfter(where);
     }
     /**
@@ -853,7 +853,7 @@ with_jquery(function($) {
       var _autoLinkAction = function() {
         what(placeCommentIn, Target.Closure);
       };
-      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\">auto</a>").click(_autoLinkAction));
+      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\" style=\"margin-left: 1em;\">auto</a>").click(_autoLinkAction));
       autoLink.insertAfter(where);
     }
 
@@ -873,7 +873,7 @@ with_jquery(function($) {
       var _autoLinkAction = function() {
         what(placeCommentIn, Target.EditSummaryQuestion);
       };
-      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\" style=\"float:right;\">auto</a>").click(_autoLinkAction));
+      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\" style=\"margin-left: 1em;\" style=\"float:right;\">auto</a>").click(_autoLinkAction));
       autoLink.insertAfter(where);
     }
 


### PR DESCRIPTION
Add margin-left: 1em to the link style in order to align with help link above.

At least in my browser the "auto" link position is unaligned with help and overrides comment section. I checked help link style and found it has the "margin-left: 1em" style that I included.