### PR TITLE
Fix for endless recursive errors

### DIFF
--- a/dist/autoreviewcomments.user.js
+++ b/dist/autoreviewcomments.user.js
@@ -823,7 +823,7 @@ function CheckForNewVersion(popup) {
       $("#content").delegate(triggerSelector, "click", function(event) {
         /** @type jQuery */
         var triggerElement = $(event.target);
-        _internalInjector(triggerElement);
+        _internalInjector(triggerElement, 0);
       });
     }
     attachAutoLinkInjector(".js-add-link", findCommentElements, injectAutoLink, autoLinkAction);


### PR DESCRIPTION
The initial call to `_internalInjector` needs the second parameter, `retryCount`, to start at 0, not `undefined`, otherwise, if the process doesn't succeed, the recursive call of `(triggerElement, retryCount + 1);` will result in `undefined + 1` or `NaN` for `retryCount` and an endless recursive loop, because the `if (20 <= retryCount) return;` condition never passes.