### PR TITLE
Change "Auto" link to uppercase, for consistency with UI

### DIFF
--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -805,7 +805,7 @@ with_jquery(function($) {
       var _autoLinkAction = function() {
         what(placeCommentIn, posttype);
       };
-      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\">auto</a>").click(_autoLinkAction));
+      var autoLink = $("<span class=\"lsep\"> | </span>").add($("<a class=\"comment-auto-link\">Auto</a>").click(_autoLinkAction));
       autoLink.insertAfter(where);
     }
     /**


### PR DESCRIPTION
SE changed the casing of the "Help" button and the "Add a comment" and "Show [x] more comments" buttons from all-lowercase to sentence case. Change the link provided by this script to be consistent with the new UI.