### PR TITLE
Fix auto link to show up next to the custom close question reason from Stack Exchange changes

### DIFF
--- a/src/.templates/popup.html
+++ b/src/.templates/popup.html
@@ -1,4 +1,4 @@
-<div class="auto-review-comments popup" id="popup">
+<div class="auto-review-comments popup z-modal" id="popup">
   <div class="popup-close" id="close"><a title="close this popup (or hit Esc)">&#215;</a></div>
   <h2 class="handle">Which review comment to insert?</h2>
 

--- a/src/autoreviewcomments.user.js
+++ b/src/autoreviewcomments.user.js
@@ -734,7 +734,7 @@ with_jquery(function($) {
     }
     attachAutoLinkInjector(".js-add-link", findCommentElements, injectAutoLink, autoLinkAction);
     attachAutoLinkInjector(".edit-post", findEditSummaryElements, injectAutoLinkEdit, autoLinkAction);
-    attachAutoLinkInjector(".close-question-link", findClosureElements, injectAutoLinkClosure, autoLinkAction);
+    attachAutoLinkInjector(".js-close-question-link", findClosureElements, injectAutoLinkClosure, autoLinkAction);
     attachAutoLinkInjector(".review-actions input:first", findReviewQueueElements, injectAutoLinkReviewQueue, autoLinkAction);
 
     /**
@@ -768,7 +768,7 @@ with_jquery(function($) {
      *                     comment should be placed.
      */
     function findClosureElements(where) {
-      var injectNextTo = $(".close-as-off-topic-pane textarea");
+      var injectNextTo = $("#site-specific-comment textarea");
       var placeCommentIn = injectNextTo;
       return [injectNextTo, placeCommentIn];
     }
@@ -952,7 +952,7 @@ with_jquery(function($) {
       //We only actually perform the updates check when someone clicks, this should make it less costly, and more timely
       //also wrap it so that it only gets called the *FIRST* time we open this dialog on any given page (not much of an optimisation).
       if (typeof CheckForNewVersion == "function" && !window.VersionChecked) {
-        CheckForNewVersion(popup); // eslint-disable-line no-undef 
+        CheckForNewVersion(popup); // eslint-disable-line no-undef
         window.VersionChecked = true;
       }
     }


### PR DESCRIPTION
Stack Exchange revamped the question close dialog.  The selectors used by this plugin need to be updated as a result.